### PR TITLE
EE-7488 Remove configuation object that no longer exists

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -187,11 +187,6 @@ spec:
                 configMapKeyRef:
                   name: rest-retry-config
                   key: AUDIT_SERVICE_RETRY_DELAY
-            - name: REFRESH_INTERVAL
-              valueFrom:
-                configMapKeyRef:
-                  name: endpoint-config
-                  key: HMRC_ACCESS_CODE_REFRESH_INTERVAL
             - name: PTTG_DB_HOSTNAME
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
We do not have a refresh interval for the hmrc access code anymore as
this doesn't do anything in the HMRC service.  Instead we just cache
the access code until it expires, then ask the access code service to
generate a new one.