### PR TITLE
reduce nginx connection timeout

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -111,7 +111,7 @@ spec:
             - name: SERVER_KEY
               value: /certs/tls-key.pem
             - name: ADD_NGINX_LOCATION_CFG
-              value: 'proxy_read_timeout 99999s; proxy_connect_timeout 99999s;'
+              value: 'proxy_read_timeout 99999s; proxy_connect_timeout 60s;'
             - name: ADD_NGINX_SERVER_CFG
               value: 'gzip off; location = /reload { allow 127.0.0.1; deny all; content_by_lua_block { os.execute("touch /tmp/nginx-reload-triggered; /usr/local/openresty/nginx/sbin/nginx -s reload; touch /tmp/nginx-reload-complete;") } }'
           volumeMounts:


### PR DESCRIPTION
Reduction of nginx connection timeout to be inline with other services. Nginx docs state that connection timeouts should not exceed 75s.